### PR TITLE
Define event in the open file dialog callback

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,10 +23,12 @@ app.on('ready', function appReady () {
   mainWindow = new BrowserWindow({width: 800, height: 600})
   mainWindow.loadUrl('file://' + __dirname + '/index.html')
 
-  ipc.on('open-file-dialog', function () {
-   var files = dialog.showOpenDialog({ properties: [ 'openFile', 'openDirectory' ]})
-   if (files) event.sender.send('selected-directory', files)
-   })
+  ipc.on('open-file-dialog', function (event) {
+    var files = dialog.showOpenDialog({ properties: [ 'openFile', 'openDirectory' ]})
+    if (files) {
+      event.sender.send('selected-directory', files)
+    }
+  })
 
   if (process.platform === 'darwin') {
     menu = Menu.buildFromTemplate(darwinTemplate(app, mainWindow))


### PR DESCRIPTION
The `event` definition was missing and an error was being thrown.
Now verifying the repository works well.

I really like to follow this project so I see how applications are built with Electron. :sparkles: :smile: